### PR TITLE
feat: Add favicon to the website

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -14,6 +14,9 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
+      <head>
+        <link rel="icon" href="/assets/img/logo.svg" />
+      </head>
       <body className={inter.className}>
         <ProviderWrapper>
           <NavBar /> {/* Add the NavBar component here */}


### PR DESCRIPTION
This commit adds a favicon to the website by including a link to the favicon file in the head section of the layout.jsx file. The favicon file is located at "/assets/img/logo.svg". This enhancement improves the visual appearance of the website and provides a recognizable icon for users when bookmarking or saving the website.